### PR TITLE
[Pre-commit] Run popie only once

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,5 @@ repos:
     rev: v1.10.1
     hooks:
     - id: popie
-      args: [--detached]
+      args: [".", "--detached"]
+      pass_filenames: false


### PR DESCRIPTION
Pre-commit is run on the changed files, but we want to run it only once on whole repo.