### PR TITLE
[Karma] Fix reaction removed

### DIFF
--- a/karma/module.py
+++ b/karma/module.py
@@ -743,8 +743,8 @@ class Karma(commands.Cog):
         else:
             await self.reaction_removed(
                 guild_id=reaction.guild_id,
-                message_author=message.author.id,
-                reaction_author=reaction.user_id,
+                msg_author_id=message.author.id,
+                react_author_id=reaction.user_id,
                 emoji_value=emoji_value,
             )
 


### PR DESCRIPTION
```
CRITICAL: Uncaught error bubbled-up.
Traceback: 
Karma.reaction_removed() got an unexpected keyword argument 'message_author'
  File "/root/.local/lib/python3.12/site-packages/discord/client.py", line 449, in _run_event
    await coro(*args, **kwargs)

  File "/strawberry-py/modules/boards/karma/module.py", line 93, in on_raw_reaction_remove
    await self._process_reaction(reaction=reaction, added=False)

  File "/strawberry-py/modules/boards/karma/module.py", line 744, in _process_reaction
    await self.reaction_removed(
          ^^^^^^^^^^^^^^^^^^^^^^
```