### PR TITLE
Refactor database to SQLAlchemy 2.0 + update builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/messages/database.py
+++ b/messages/database.py
@@ -1,26 +1,17 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from sqlalchemy import (
-    ARRAY,
-    BigInteger,
-    Boolean,
-    Column,
-    DateTime,
-    Integer,
-    String,
-    asc,
-    desc,
-    func,
-    update,
-)
-from sqlalchemy.orm import Query
+from sqlalchemy import ARRAY, BigInteger, DateTime, Integer, asc, desc, func, update
+from sqlalchemy.orm import Mapped, Query, mapped_column
 from sqlalchemy.orm.attributes import flag_modified
 
 import discord
 
 from pie.database import database, session
+
+VERSION = 1
 
 
 class UserChannelConfig(database.base):
@@ -34,9 +25,11 @@ class UserChannelConfig(database.base):
 
     __tablename__ = "boards_messages_config"
 
-    guild_id = Column(BigInteger, primary_key=True, autoincrement=False)
-    ignored_channels = Column(ARRAY(BigInteger))
-    ignored_members = Column(ARRAY(BigInteger))
+    guild_id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=False
+    )
+    ignored_channels: Mapped[list[int]] = mapped_column(ARRAY(BigInteger))
+    ignored_members: Mapped[list[int]] = mapped_column(ARRAY(BigInteger))
 
     @staticmethod
     def add(
@@ -135,16 +128,16 @@ class UserChannel(database.base):
 
     __tablename__ = "boards_messages_userchannels"
 
-    idx = Column(Integer, primary_key=True, autoincrement=True)
-    guild_id = Column(BigInteger)
-    guild_name = Column(String)
-    channel_id = Column(BigInteger)
-    channel_name = Column(String)
-    user_id = Column(BigInteger)
-    user_name = Column(String)
-    is_webhook = Column(Boolean)
-    count = Column(BigInteger, default=1)
-    last_msg_at = Column(DateTime)
+    idx: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger)
+    guild_name: Mapped[str]
+    channel_id: Mapped[int] = mapped_column(BigInteger)
+    channel_name: Mapped[str]
+    user_id: Mapped[int] = mapped_column(BigInteger)
+    user_name: Mapped[str]
+    is_webhook: Mapped[bool]
+    count: Mapped[int] = mapped_column(BigInteger, default=1)
+    last_msg_at: Mapped[datetime] = mapped_column(DateTime)
 
     @staticmethod
     def increment(message: discord.Message, positive: bool) -> UserChannel:

--- a/points/database.py
+++ b/points/database.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from sqlalchemy import BigInteger, Column, Integer, func
+from sqlalchemy import BigInteger, Integer, func
+from sqlalchemy.orm import Mapped, mapped_column
 
 from pie.database import database, session
+
+VERSION = 1
 
 
 class BoardOrder(Enum):
@@ -18,7 +21,7 @@ class Setup(database.base):
 
     __tablename__ = "boards_points_setup"
 
-    guild_id = Column(BigInteger, primary_key=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     @classmethod
     def get(cls, guild_id: int) -> Optional[Setup]:
@@ -56,10 +59,10 @@ class UserStats(database.base):
 
     __tablename__ = "boards_points_users"
 
-    idx = Column(Integer, primary_key=True, autoincrement=True)
-    guild_id = Column(BigInteger)
-    user_id = Column(BigInteger)
-    points = Column(Integer)
+    idx: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger)
+    user_id: Mapped[int] = mapped_column(BigInteger)
+    points: Mapped[int]
 
     @staticmethod
     def get_stats(guild_id: int, user_id: int) -> UserStats:


### PR DESCRIPTION
- refactor databases to SQLAlchemy 2.0
- drop support for Python 3.8
- add support for Python 3.13
- add DB version support