### PR TITLE
[Karma] Fix guild_id in KarmaMember

### DIFF
--- a/karma/database.py
+++ b/karma/database.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from pie.database import database, session
 
-VERSION = 1
+VERSION = 2
 
 
 class BoardOrder(Enum):
@@ -26,7 +26,7 @@ class KarmaMember(database.base):
     __tablename__ = "boards_karma_members"
 
     idx: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    guild_id: Mapped[int]
+    guild_id: Mapped[int] = mapped_column(BigInteger, default=None)
     user_id: Mapped[int] = mapped_column(BigInteger, default=None)
     value: Mapped[int] = mapped_column(Integer, default=0)
     given: Mapped[int] = mapped_column(Integer, default=0)

--- a/karma/updates/update_1_to_2.py
+++ b/karma/updates/update_1_to_2.py
@@ -1,0 +1,40 @@
+"""This is an example on how to handle DB updates from version to version
+
+The name of the file must be update_{version}_to_{version+1}.py
+For example: `update_1_to_2.py`
+The file must be placed into folder `updates` located in the same directory
+as database.py file for the module
+For example:
+    `./pie/acl/updates/update_1_to_2.py`
+    `./modules/base/errors/updates/update_1_to_2.py`
+
+The update can be done only from version to version + 1 (can't skip versions).
+
+The inspector should be used to figure out if the update is needed.
+It might happen that the module with newer schema is freshly installed
+before the core is updated to the version that supports DB updates
+"""
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import BigInteger, inspect
+
+from pie.database import database
+
+
+def run():
+    inspector = inspect(database.db)
+    with database.db.connect() as conn:
+        mc = MigrationContext.configure(conn)
+        with mc.begin_transaction():
+            ops = Operations(mc)
+
+            karma_columns = [
+                column["name"]
+                for column in inspector.get_columns("boards_karma_members")
+            ]
+
+            if "guild_id" in karma_columns:
+                ops.alter_column(
+                    "boards_karma_members", column_name="guild_id", type_=BigInteger
+                )


### PR DESCRIPTION
```
CRITICAL: strawberry.py database session rolled back. The bubbled-up cause is:
| This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.errors.NumericValueOutOfRange) integer out of range
| 
| [SQL: INSERT INTO boards_karma_members (guild_id, user_id, value, given, taken) VALUES (%(guild_id)s, %(user_id)s, %(value)s, %(given)s, %(taken)s) RETURNING boards_karma_members.idx]
| [parameters: {'guild_id': 810483333812584478, 'user_id': 306509933237764096, 'value': 0, 'given': 0, 'taken': 0}]
| (Background on this error at: https://sqlalche.me/e/20/9h9h) (Background on this error at: https://sqlalche.me/e/20/7s2a)
```