### PR TITLE
[Starboard] Always fetch messages for reactions

### DIFF
--- a/starboard/module.py
+++ b/starboard/module.py
@@ -580,6 +580,7 @@ class Starboard(commands.Cog):
                 guild_or_user_id=reaction.guild_id,
                 channel_id=reaction.channel_id,
                 message_id=reaction.message_id,
+                use_cache=False,  # We need fresh CDN link for attachments
             )
         except Exception:
             pass


### PR DESCRIPTION
Fixes the issue where the message attachments were raising 404.

Has to be merged after https://github.com/strawberry-py/strawberry-py/pull/95