### PR TITLE
[Starboard] Fix logging of attachment errors

### DIFF
--- a/starboard/module.py
+++ b/starboard/module.py
@@ -656,7 +656,7 @@ class Starboard(commands.Cog):
         attachments: list[discord.Attachment] = message.attachments
         msg_content: str = message.content
         embed_image: Union[discord.File, str] = None
-        secondary_attachments = []
+        secondary_attachments: list[Union[str, discord.File]] = []
         for attachment in attachments:
             try:
                 attachment_file = await attachment.to_file()

--- a/starboard/module.py
+++ b/starboard/module.py
@@ -645,16 +645,17 @@ class Starboard(commands.Cog):
             )
 
     async def _process_attachments(
-        self, attachments: list[discord.Attachment], msg_content: str
+        self, message: discord.Message
     ) -> tuple[Optional[Union[discord.File, str]], list[Union[str, discord.File]]]:
         """Processes attachements for the repost.
 
-        :param attachments: List of original message attachments
-        :param msg_content: Text content of the original message
+        :param message: Original message to process
 
         :returns: Tuple with (optional) embed image and list of other attachments.
         """
-        embed_image = None
+        attachments: list[discord.Attachment] = message.attachments
+        msg_content: str = message.content
+        embed_image: Union[discord.File, str] = None
         secondary_attachments = []
         for attachment in attachments:
             try:
@@ -662,7 +663,7 @@ class Starboard(commands.Cog):
             except Exception as ex:
                 await guild_log.debug(
                     None,
-                    None,
+                    message.channel,
                     f"Error loading attachment {attachment.url}.",
                     exception=ex,
                 )
@@ -710,9 +711,7 @@ class Starboard(commands.Cog):
             inline=False,
         )
 
-        embed_image, sec_attachments = await self._process_attachments(
-            attachments=message.attachments, msg_content=message.content
-        )
+        embed_image, sec_attachments = await self._process_attachments(message=message)
         if embed_image is not None:
             embed.set_image(
                 url=(


### PR DESCRIPTION
When using guild_log with empty LogSource (2nd positional parameter), the error gets logged only into log file and console, but not to the channel.

We can fix this by passing the message instead of the attachments and content to the function, so we can obtain the message channel and use it as LogSource.

I've also added typing to the two variables.