### PR TITLE
[Karma] Fix logging on non-existing message

### DIFF
--- a/karma/module.py
+++ b/karma/module.py
@@ -748,7 +748,7 @@ class Karma(commands.Cog):
                 None,
                 None,
                 f"Message {reaction.message_id} not found on karma reaction add "
-                "by user {reaction.user_id} in channel {reaction.channel_id}.",
+                f"by user {reaction.user_id} in channel {reaction.channel_id}.",
             )
             return
         if added:

--- a/karma/module.py
+++ b/karma/module.py
@@ -745,9 +745,10 @@ class Karma(commands.Cog):
 
         if message is None:
             await guild_log.debug(
-                reaction.user_id,
-                reaction.channel_id,
-                f"Message {reaction.message_id} not found on karma reaction add.",
+                None,
+                None,
+                f"Message {reaction.message_id} not found on karma reaction add "
+                "by user {reaction.user_id} in channel {reaction.channel_id}.",
             )
             return
         if added:


### PR DESCRIPTION
```
CRITICAL: Uncaught error bubbled-up.
Traceback: 
sequence item 1: expected str instance, NoneType found
  File "/root/.local/lib/python3.12/site-packages/discord/client.py", line 449, in _run_event
    await coro(*args, **kwargs)

  File "/strawberry-py/modules/boards/karma/module.py", line 93, in on_raw_reaction_add
    await self._process_reaction(reaction=reaction, added=True)

  File "/strawberry-py/modules/boards/karma/module.py", line 747, in _process_reaction
    await guild_log.debug(

  File "/strawberry-py/pie/logger/__init__.py", line 324, in debug
    await self._log(

  File "/strawberry-py/pie/logger/__init__.py", line 265, in _log
    stdout: str = entry.format_to_console()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/strawberry-py/pie/logger/__init__.py", line 216, in format_to_console
    return timestamp + " " + self._format_as_string(extended=True)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/strawberry-py/pie/logger/__init__.py", line 199, in _format_as_string
    message: str = " ".join(stubs) + f": {self.message}"
```